### PR TITLE
feat: support Windows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             asset_name: dnspeep-linux.tar.gz
+            features: pcap_unix
           - name: macos
             target: x86_64-apple-darwin
             os: macos-latest
             asset_name: dnspeep-macos.tar.gz
+            features: pcap_unix
     steps:
     - uses: actions/checkout@v1
 
@@ -58,7 +60,7 @@ jobs:
         rustup target add ${{ matrix.target }}
 
     - name: Build
-      run: cargo build --release --locked --target ${{ matrix.target }}
+      run: cargo build --release --locked --target ${{ matrix.target }} --features ${{ matrix.features }}
 
     - name: Create release tarball
       run: tar -C target/${{matrix.target}}/release/ -czf ${{ matrix.asset_name }} dnspeep 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "dnspeep"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes 1.0.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "dnspeep"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Julia Evans <julia@jvns.ca>"]
 edition = "2018"
 
 [dependencies]
-pcap = { git = "https://github.com/jvns/pcap", features=["capture-stream"] }
+pcap = { git = "https://github.com/jvns/pcap" }
 libc = "0.2.80"
 dns-message-parser = "~0.5"
 etherparse = "0.9.0"
@@ -16,3 +16,8 @@ getopts = "0.2.17"
 bytes = "~1.0"
 hex = "~0.4"
 chrono = "0.4.19"
+
+[features]
+default = []
+pcap_windows = []
+pcap_unix = ["pcap/capture-stream"]


### PR DESCRIPTION
* capture packets from an interface
* conditional compilation
* fix overflow in get_time function

There's one thing needs to pay attention to(in Cargo.toml). Since we only enable pcap's **capture-stream** feature on unix, we need to update the `publish.yml` file to pass down the `--features` arguments for `cargo build`.

I have not set up the CI for Windows build yet **!!!** 