### PR TITLE
Added option to specify the network interface (now it works on FreeBSD)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use futures::StreamExt;
 use getopts::Options;
 use hex::encode;
 use pcap::stream::{PacketCodec, PacketStream};
-use pcap::{Active, Capture, Linktype, Packet};
+use pcap::{Active, Capture, Device, Linktype, Packet};
 use std::collections::HashMap;
 use std::env;
 use std::net::IpAddr;
@@ -34,6 +34,7 @@ struct OrigPacket {
 struct Opts {
     source: Source,
     timestamp: bool,
+    nic: String,
 }
 
 #[derive(Clone)]
@@ -99,6 +100,7 @@ fn parse_args() -> Result<Opts> {
 
     let mut opts = Options::new();
     opts.optopt("p", "port", "port number to listen on", "PORT");
+    opts.optopt("i", "interface", "network interface to listen on", "NIC");
     opts.optopt("f", "file", "read packets from pcap file", "FILENAME");
     opts.optflag(
         "t",
@@ -109,7 +111,7 @@ fn parse_args() -> Result<Opts> {
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
-            panic!(f.to_string())
+            panic!("{}", f.to_string())
         }
     };
     if matches.opt_present("h") {
@@ -119,7 +121,12 @@ fn parse_args() -> Result<Opts> {
     let mut opts = Opts {
         source: Source::Port(53),
         timestamp: matches.opt_present("t"),
+        nic: "any".to_string(),
     };
+
+    if let Some(nic) = matches.opt_str("i") {
+        opts.nic = nic.to_string();
+    }
 
     if let Some(filename) = matches.opt_str("f") {
         opts.source = Source::Filename(filename.to_string());
@@ -169,8 +176,13 @@ fn capture_stream(
     map: Arc<Mutex<HashMap<u16, OrigPacket>>>,
     port: u16,
 ) -> Result<PacketStream<Active, PrintCodec>> {
-    let mut cap = Capture::from_device("any")
-        .wrap_err("Failed to find device 'any'")?
+    let _nic = Device {
+        name: opts.nic.clone(),
+        desc: std::option::Option::None,
+    };
+    let wrap_err_msg = format!("Failed to find device '{}'", opts.nic);
+    let mut cap = Capture::from_device(_nic)
+        .wrap_err(wrap_err_msg)?
         .immediate_mode(true)
         .open()
         .wrap_err("Failed to start. This may be because you need to run this as root.")?


### PR DESCRIPTION
Hi,
this is a pull request to fix my issue [#20 ](https://github.com/jvns/dnspeep/issues/20).
It adds a new command line parameter to specify a network interface to listen on.
Now it works on FreeBSD (because it doesn't support the "any" inferface).
Bye,
Riccardo