### PR TITLE
🚸 print version when printing usage information with '-h'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,9 @@ What the output columns mean:
    response:  Responses from the Answer section of the DNS response (or \"<no response>\" if none was found).
               Multiple responses are separated by commas.
 ");
+    println!("
+Your are running version v0.1.4.
+");
 }
 
 fn capture_file(opts: &Opts, filename: &str) -> Result<()> {


### PR DESCRIPTION
This PR will solve issue #22 and print version when printing usage information with '-h'.
⚠️ Version is currently hard-coded because I have no idea of Rust and how to make this more elegant 🤷🏻‍♂️ 