### PR TITLE
Update README to reflect change to dns-message-parser library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 pcap = { git = "https://github.com/jvns/pcap", features=["capture-stream"] }
 libc = "0.2.150"
+# Update link in README.md when incrementing this version
 dns-message-parser = "~0.6"
 etherparse = "0.9.0"
 tokio = { version = "0.2", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ prints them out with the response `<no response>`.
 
 ### Limitations
 
-* Only supports the DNS query types supported by the `dns_parser` crate ([here's a list](https://docs.rs/dns-parser/0.8.0/dns_parser/))
+* Only supports the DNS query types supported by the `dns-message-parser` crate ([here's a list](https://docs.rs/dns-message-parser/0.6.0/dns_message_parser/rr/enum.RR.html))
 * Doesn't support TCP DNS queries, only UDP
 * It can't show DNS-over-HTTPS queries (because it would need to MITM the HTTPS connection)


### PR DESCRIPTION
This was an omission from db8c8ee6cfe669f4c77fc6995edb8c7aa26c7a58